### PR TITLE
KOGITO-1475 UserTask quickstart has incorrect user

### DIFF
--- a/kogito-usertasks-quarkus/README.md
+++ b/kogito-usertasks-quarkus/README.md
@@ -142,14 +142,14 @@ This should return empty response as the manager user was the first approver and
 Repeating the request with another user will return task
 
 ```
-curl -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/tasks?john=manager&group=managers'
+curl -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/tasks?user=john&group=managers'
 ```
 
 
 ### Complete second line approval task
 
 ```
-curl -X POST -d '{"approved" : true}' -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/secondLineApproval/{tuuid}?john=manager&group=managers'
+curl -X POST -d '{"approved" : true}' -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/secondLineApproval/{tuuid}?user=john&group=managers'
 ```
 
 where `{uuid}` is the id of the given approval instance and `{tuuid}` is the id of the task instance

--- a/kogito-usertasks-quarkus/README.md
+++ b/kogito-usertasks-quarkus/README.md
@@ -115,7 +115,7 @@ curl -H 'Content-Type:application/json' -H 'Accept:application/json' http://loca
 ### Show tasks 
 
 ```
-curl -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/tasks?user=admin&group=managers'
+curl -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/tasks?user=manager&group=managers'
 ```
 
 where `{uuid}` is the id of the given approval instance
@@ -124,7 +124,7 @@ where `{uuid}` is the id of the given approval instance
 ### Complete first line approval task
 
 ```
-curl -X POST -d '{"approved" : true}' -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/firstLineApproval/{tuuid}?user=admin&group=managers'
+curl -X POST -d '{"approved" : true}' -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/firstLineApproval/{tuuid}?user=manager&group=managers'
 ```
 
 where `{uuid}` is the id of the given approval instance and `{tuuid}` is the id of the task instance
@@ -132,24 +132,24 @@ where `{uuid}` is the id of the given approval instance and `{tuuid}` is the id 
 ### Show tasks 
 
 ```
-curl -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/tasks?user=admin&group=managers'
+curl -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/tasks?user=manager&group=managers'
 ```
 
 where `{uuid}` is the id of the given approval instance
 
-This should return empty response as the admin user was the first approver and by that can't be assigned to another one.
+This should return empty response as the manager user was the first approver and by that can't be assigned to another one.
 
 Repeating the request with another user will return task
 
 ```
-curl -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/tasks?john=admin&group=managers'
+curl -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/tasks?john=manager&group=managers'
 ```
 
 
 ### Complete second line approval task
 
 ```
-curl -X POST -d '{"approved" : true}' -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/secondLineApproval/{tuuid}?john=admin&group=managers'
+curl -X POST -d '{"approved" : true}' -H 'Content-Type:application/json' -H 'Accept:application/json' 'http://localhost:8080/approvals/{uuid}/secondLineApproval/{tuuid}?john=manager&group=managers'
 ```
 
 where `{uuid}` is the id of the given approval instance and `{tuuid}` is the id of the task instance
@@ -159,7 +159,7 @@ plus the approver who made the first one.
 
 ```
 {
-	"approver":"admin",
+	"approver":"manager",
 	"firstLineApproval":true,
 	"id":"2eeafa82-d631-4554-8d8e-46614cbe3bdf",
 	"secondLineApproval":true,
@@ -180,6 +180,6 @@ plus the approver who made the first one.
 You should see a similar message after performing the second line approval after the curl command
 
 ```
-{"id":"f498de73-e02d-4829-905e-2f768479a4f1", "approver":"admin","firstLineApproval:true, "secondLineApproval":true,"traveller":{"firstName":"John","lastName":"Doe","email":"jon.doe@example.com","nationality":"American","address":{"street":"main street","city":"Boston","zipCode":"10005","country":"US"}}}
+{"id":"f498de73-e02d-4829-905e-2f768479a4f1", "approver":"manager","firstLineApproval:true, "secondLineApproval":true,"traveller":{"firstName":"John","lastName":"Doe","email":"jon.doe@example.com","nationality":"American","address":{"street":"main street","city":"Boston","zipCode":"10005","country":"US"}}}
 ```
 


### PR DESCRIPTION
Hi @cristianonicolai, @inodeman, **just a side question, not about this particular PR**.

In the tutorial it is also `managers` group is used. But when I tried to use it - it never affect anything. 
* If I have no user name in `/approvals/{id}/tasks` request but group `managers` is set, I expect that I will see all available tasks for `managers` group, but it returns an empty response.
* If I put there no group, only user name all works fine, I see one task.
* When I put `manager` user and incorrect group, something like `manadafiasn` it is the same as I put user name only - one task will be returned.

 So, my question is what `group` parameter is supposed to do? Is it not finished yet or am I missing something?

```
kgaevski@localhost:kogito-usertasks-quarkus:master $ curl -X GET "http://localhost:8080/approvals/ef166fa1-0581-45ae-94d7-209132f0f607/tasks?group=managers" -H  "accept: application/json"
{}

kgaevski@localhost:kogito-usertasks-quarkus:master $ curl -X GET "http://localhost:8080/approvals/ef166fa1-0581-45ae-94d7-209132f0f607/tasks?user=manager" -H  "accept: application/json"
{"2121c7c0-a203-4a37-9248-c0eb8ed1b1bd":"firstLineApproval"}

kgaevski@localhost:kogito-usertasks-quarkus:master $ 
```

![image](https://user-images.githubusercontent.com/1477262/76864621-afdf8800-6861-11ea-9cda-fea798301d6c.png)
